### PR TITLE
fix: Corriger la construction du chemin dans handleItemDoubleClick du…

### DIFF
--- a/src/components/ui/file-browser.tsx
+++ b/src/components/ui/file-browser.tsx
@@ -228,17 +228,17 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
   // Gestion du double-clic pour naviguer dans les dossiers
   const handleItemDoubleClick = useCallback((item: FileItem) => {
     if (item.is_directory && onNavigate) {
-      // Construire le nouveau chemin
-      const newPath = item.parent_path
-        ? `${item.parent_path}/${item.file_name}`
-        : `/${item.file_name}`;
+      // Construire le nouveau chemin à partir du currentPath
+      const newPath = currentPath === "/"
+        ? `/${item.file_name}`
+        : `${currentPath}/${item.file_name}`;
 
       onNavigate(newPath);
 
       // Désélectionner tous les items après navigation
       setSelectedItems(new Set());
     }
-  }, [onNavigate]);
+  }, [onNavigate, currentPath]);
 
   // Gestion de la sélection
   const handleItemSelect = useCallback((item: FileItem, index: number, shiftKey: boolean, ctrlKey: boolean) => {


### PR DESCRIPTION
… FileBrowser

- Utiliser currentPath au lieu de item.parent_path pour construire le chemin complet
- Assure que le double-clic sur un dossier transmet le chemin complet à onNavigate
- Exemple: depuis /dossierA, double-clic sur dossierB génère /dossierA/dossierB au lieu de /dossierB

🤖 Generated with [Claude Code](https://claude.com/claude-code)