### PR TITLE
fix: Corriger le fallback du breadcrumb et ajouter des logs de debug …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gs/gs-components-library",
-  "version": "0.3.0-beta.5",
+  "version": "0.3.0-beta.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/file-browser.tsx
+++ b/src/components/ui/file-browser.tsx
@@ -236,6 +236,9 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
     if (item.is_directory && onNavigate) {
       // Construire le nouveau chemin en préservant le format (avec ou sans "/" au début)
       let newPath: string;
+
+      console.log('[FileBrowser] handleItemDoubleClick - currentPath:', currentPath, 'file_name:', item.file_name);
+
       if (!currentPath || currentPath === "") {
         newPath = item.file_name;
       } else if (currentPath === "/") {
@@ -244,6 +247,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
         newPath = `${currentPath}/${item.file_name}`;
       }
 
+      console.log('[FileBrowser] handleItemDoubleClick - constructed newPath:', newPath);
       onNavigate(newPath);
 
       // Désélectionner tous les items après navigation
@@ -583,7 +587,7 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
             <>
               <Button
                 size="large"
-                onClick={() => onNavigate?.(pathSegments[pathSegments.length - 3]?.path || "/")}
+                onClick={() => onNavigate?.(pathSegments[pathSegments.length - 3]?.path || "")}
               >
                 <IconProvider icon="MoreHorizontal" size={16} />
               </Button>


### PR DESCRIPTION
…dans FileBrowser

- Remplacer le fallback || "/" par || "" dans la navigation breadcrumb pour éviter d'ajouter un slash non désiré
- Ajouter des logs de debug dans handleItemDoubleClick pour tracer la construction des chemins
- Garantir que les chemins absolus sont préservés sans être tronqués

🤖 Generated with [Claude Code](https://claude.com/claude-code)