### PR TITLE
fix: Réinitialiser le menu des actions en masse après sélection dans …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gs/gs-components-library",
-  "version": "0.3.0-beta.6",
+  "version": "0.3.0-beta.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/file-browser.tsx
+++ b/src/components/ui/file-browser.tsx
@@ -698,11 +698,14 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
 
           {/* Actions en masse (visible uniquement avec sélection) */}
           {hasSelection && (
-            <Select onValueChange={(value) => {
-              if (value !== "placeholder") {
-                handleAction(value, getSelectedItems());
-              }
-            }}>
+            <Select
+              value=""
+              onValueChange={(value) => {
+                if (value !== "placeholder" && value !== "") {
+                  handleAction(value, getSelectedItems());
+                }
+              }}
+            >
               <SelectTrigger className="w-48">
                 <SelectValue placeholder={`${selectedItems.size} sélectionné${selectedItems.size > 1 ? "s" : ""}`} />
               </SelectTrigger>


### PR DESCRIPTION
…FileBrowser

Le Select des actions en masse conserve maintenant une valeur vide pour se réinitialiser automatiquement après chaque action, permettant de revenir immédiatement à l'affichage du placeholder avec le nombre d'éléments sélectionnés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)