### PR TITLE
feat: Ajouter la sélection étendue avec Shift+Flèches dans FileBrowser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gs/gs-components-library",
-  "version": "0.3.0-beta.9",
+  "version": "0.3.0-beta.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/ui/file-browser.tsx
+++ b/src/components/ui/file-browser.tsx
@@ -345,9 +345,20 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
         setActiveIndex(prev => {
           const newIndex = prev === null ? 0 : Math.min(prev + 1, sortedFiles.length - 1);
           if (sortedFiles[newIndex]) {
-            // Sélectionner l'item actif
-            setSelectedItems(new Set([sortedFiles[newIndex].id]));
-            setLastSelectedIndex(newIndex);
+            if (e.shiftKey && lastSelectedIndex !== null) {
+              // Shift+Flèche : Étendre la sélection
+              const start = Math.min(lastSelectedIndex, newIndex);
+              const end = Math.max(lastSelectedIndex, newIndex);
+              const newSelection = new Set<string>();
+              for (let i = start; i <= end; i++) {
+                newSelection.add(sortedFiles[i].id);
+              }
+              setSelectedItems(newSelection);
+            } else {
+              // Sans Shift : Remplacer la sélection
+              setSelectedItems(new Set([sortedFiles[newIndex].id]));
+              setLastSelectedIndex(newIndex);
+            }
           }
           return newIndex;
         });
@@ -359,9 +370,20 @@ export const FileBrowser: React.FC<FileBrowserProps> = ({
         setActiveIndex(prev => {
           const newIndex = prev === null ? 0 : Math.max(prev - 1, 0);
           if (sortedFiles[newIndex]) {
-            // Sélectionner l'item actif
-            setSelectedItems(new Set([sortedFiles[newIndex].id]));
-            setLastSelectedIndex(newIndex);
+            if (e.shiftKey && lastSelectedIndex !== null) {
+              // Shift+Flèche : Étendre la sélection
+              const start = Math.min(lastSelectedIndex, newIndex);
+              const end = Math.max(lastSelectedIndex, newIndex);
+              const newSelection = new Set<string>();
+              for (let i = start; i <= end; i++) {
+                newSelection.add(sortedFiles[i].id);
+              }
+              setSelectedItems(newSelection);
+            } else {
+              // Sans Shift : Remplacer la sélection
+              setSelectedItems(new Set([sortedFiles[newIndex].id]));
+              setLastSelectedIndex(newIndex);
+            }
           }
           return newIndex;
         });


### PR DESCRIPTION
Permet d'étendre la sélection en maintenant Shift et en utilisant les touches fléchées haut/bas :
- Sans Shift : remplace la sélection (comportement actuel)
- Avec Shift : étend la sélection depuis la dernière ligne sélectionnée

Comportement standard des explorateurs de fichiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)